### PR TITLE
Add unique_irqs filter

### DIFF
--- a/scripts/codegen.py
+++ b/scripts/codegen.py
@@ -55,6 +55,20 @@ def to_snakecase(s):
 def rootname(path):
     return os.path.splitext(os.path.basename(path))[0]
 
+def unique_irqs(irqs):
+    """
+    Takes a dictionary containing the list of interrupt lines and filters them to just
+    the unique interrupt sources.
+
+    This function is made available to the template environment so that interrupt handler
+    declarations and definitions aren't repeated when multiple instances of a single IP block exist.
+    """
+    filtered_irqs = []
+    for irq in irqs:
+        if all([irq['source'] != i['source'] for i in filtered_irqs]):
+            filtered_irqs.append(irq)
+    return filtered_irqs
+
 driver_ids = dict()
 
 def assign_ids(dts, devices):
@@ -278,4 +292,5 @@ def main():
     render_templates(args, template_data)
 
 if __name__ == "__main__":
+    jinja2.filters.FILTERS['unique_irqs'] = unique_irqs
     main()

--- a/templates/metal/interrupt_handlers.h.j2
+++ b/templates/metal/interrupt_handlers.h.j2
@@ -1,4 +1,3 @@
-/* Copyright 2020 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #ifndef __INTERRUPT_HANDLERS_H
@@ -75,7 +74,7 @@ void metal_riscv_plic0_source_0_handler() __attribute__((interrupt));
 void metal_riscv_cpu_intc_meip_handler() __attribute__((interrupt));
 {% endif %}
 {% if local_interrupts is defined %}
-{% for irq in local_interrupts.irqs %}
+{% for irq in local_interrupts.irqs|unique_irqs %}
 void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler() __attribute__((interrupt));
 {% endfor %}
 {% endif %}
@@ -95,14 +94,14 @@ void metal_riscv_plic0_source_0_handler();
 void metal_riscv_cpu_intc_meip_handler();
 {% endif %}
 {% if local_interrupts is defined %}
-{% for irq in local_interrupts.irqs %}
+{% for irq in local_interrupts.irqs|unique_irqs %}
 void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler();
 {% endfor %}
 {% endif %}
 #endif
 
 {% if global_interrupts is defined %}
-{% for irq in global_interrupts.irqs %}
+{% for irq in global_interrupts.irqs|unique_irqs %}
 void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler();
 {% endfor %}
 {% endif %}

--- a/templates/src/interrupt_handlers.c.j2
+++ b/templates/src/interrupt_handlers.c.j2
@@ -58,14 +58,14 @@ void metal_riscv_plic0_source_0_handler() __attribute((interrupt, weak, alias("_
 void metal_riscv_cpu_intc_meip_handler() __attribute__((interrupt, weak, alias("_metal_local_interrupt_handler_nop")));
 {% endif %}
 {% if local_interrupts is defined %}
-    {% for irq in local_interrupts.irqs %}
+    {% for irq in local_interrupts.irqs|unique_irqs %}
 void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler() __attribute__((interrupt, weak, alias ("_metal_local_interrupt_handler_nop")));
     {% endfor %}
 {% endif %}
 
 /* Alias default global interrupt handlers to _metal_global_interrupt_handler_nop() */
 {% if global_interrupts is defined %}
-    {% for irq in global_interrupts.irqs %}
+    {% for irq in global_interrupts.irqs|unique_irqs %}
 void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler() __attribute__((weak, alias ("_metal_global_interrupt_handler_nop")));
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
Allows the template to filter IRQs for unique interrupt sources so that
interrupt handler declarations and definitions are not repeated in
generated code.