### PR TITLE
Interrupt fixes

### DIFF
--- a/freedom-metal.make
+++ b/freedom-metal.make
@@ -3,6 +3,8 @@
 
 .DEFAULT_GOAL = $(PROGRAM)
 
+RISCV_LIBC ?= picolibc
+
 ifeq ($(RISCV_LIBC),picolibc)
 include $(FREEDOM_METAL)/metal_pico.make
 endif

--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -15,7 +15,7 @@
 
 #define PLIC_REGW(offset) (__METAL_ACCESS_ONCE((__metal_io_u32 *)(METAL_RISCV_PLIC0_0_BASE_ADDR + (offset))))
 
-extern metal_interrupt_handler_t *__metal_global_interrupt_table;
+extern metal_interrupt_handler_t __metal_global_interrupt_table[];
 
 static __inline__ unsigned int
 __metal_plic0_claim_interrupt(uint32_t hartid) {


### PR DESCRIPTION
The interrupt fix is on top; the other patch is just a default for RISCV_LIBC which we may want to set to nano instead of picolibc